### PR TITLE
more should be visible when text is hidden resolved

### DIFF
--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -47,6 +47,8 @@
         - else
           .letterDescription43
             = markdown(letter.description)
+        - truncate = letter.description.length > 300
+        .letter-content.row{ class: truncate ? 'overflow' : '' }
         %br
         %div
           %div.pull-left
@@ -58,10 +60,12 @@
           :javascript
                    !function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");
           .letterActions.pull-right
-            = link_to "More", letter_path(letter), class: 'btn-link'
+            - if truncate
+              = link_to "More", letter_path(letter), class: 'btn-link'
+            - if truncate && user_signed_in?
+              |
             - if user_signed_in?
               - if(current_user.id.to_i == letter.user_id.to_i)
-                |
                 = link_to "Edit", edit_letter_path(letter)
         %br
         %hr


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/103732877/179063259-48a1b2c9-2494-43fb-ac36-c860350b3cd2.png)
![image](https://user-images.githubusercontent.com/103732877/179063404-31c51490-de83-4f2c-98a5-e2e83e62bfbe.png)

"More "should only appear when the text is getting hidden.
I added code in the index.html.hmal and it's working smoothly and also resolved the issue of "|" appearing with an edit that looks kind of weird now the separator only appears when truncate happens and the user is logged in. #26 