### PR TITLE
Removed user attributes from User table

### DIFF
--- a/app/admin/external_identities.rb
+++ b/app/admin/external_identities.rb
@@ -1,0 +1,26 @@
+ActiveAdmin.register ExternalIdentity do
+
+  # See permitted parameters documentation:
+  # https://github.com/activeadmin/activeadmin/blob/master/docs/2-resource-customization.md#setting-up-strong-parameters
+  #
+  # Uncomment all parameters which should be permitted for assignment
+  #
+  permit_params :user_id, :provider, :uid, :oauth, :handle, :description, :website, :name, :email, :image
+  #
+  # or
+  #
+  # permit_params do
+  #   permitted = [:user_id, :provider, :uid, :oauth, :handle, :description, :website, :name, :email, :image]
+  #   permitted << :other if params[:action] == 'create' && current_user.admin?
+  #   permitted
+  # end
+
+  index do
+    column :id
+    column :name
+    column :handle
+    actions
+  end
+
+  
+end

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -9,6 +9,7 @@
       column :letters_count do |user|
         user.letters.count
       end
+      column :external_identities
       column :likes do |user|
         user.likes.count
       end

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -2,7 +2,6 @@
 
     index do
       column :id
-      column :twitter_handle
       column :name
       column :last_sign_in_at
       column :created_at

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,16 +11,16 @@ module ApplicationHelper
 
 
   def image_for_twitter_handle(user)
-    if user.updated_at.after?(RubyConfIndia2023) && user.external_identities.find_by(provider: 'twitter')&.image.present?
+    if user.updated_at.after?(RubyConfIndia2023) && user.twitter_identity&.image.present?
       # this is a quick workaround for being unable to fetch images via Cloudinary for new twitter sign_ins due to Twitter API policy changes.
       # one problem with continuing to use this long term would be:
       #   - if a user changes their profile picture, the url saved on our model will become invalid
       #      we do have a fallback to default image in place, but it's not ideal
       #   - As an improvement, we can try to cache it (more like a permanent snapshot until their next login)
       #   - But a proper solution would be to fetch their current profile picture via a service or to periodically refresh it ourself
-      user.external_identities.find_by(provider: 'twitter')&.image
+      user.twitter_identity&.image
     else
-      user_handle = user.external_identities.find_by(provider: 'twitter')&.handle
+      user_handle = user.twitter_identity&.handle
       cloudinary_image_url(user_handle)
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,23 +3,28 @@ module ApplicationHelper
     image_tag image_for_twitter_handle(user), onerror: 'this.error=null;this.src="https://abs.twimg.com/sticky/default_profile_images/default_profile_normal.png"'
   end
 
+
   private
+
 
   RubyConfIndia2023 = Date.parse('2023-08-26')
 
+
   def image_for_twitter_handle(user)
-    if user.updated_at.after?(RubyConfIndia2023) && user.image.present?
+    if user.updated_at.after?(RubyConfIndia2023) && user.external_identities.find_by(provider: 'twitter')&.image.present?
       # this is a quick workaround for being unable to fetch images via Cloudinary for new twitter sign_ins due to Twitter API policy changes.
       # one problem with continuing to use this long term would be:
       #   - if a user changes their profile picture, the url saved on our model will become invalid
       #      we do have a fallback to default image in place, but it's not ideal
       #   - As an improvement, we can try to cache it (more like a permanent snapshot until their next login)
       #   - But a proper solution would be to fetch their current profile picture via a service or to periodically refresh it ourself
-      user.image
+      user.external_identities.find_by(provider: 'twitter')&.image
     else
-      cloudinary_image_url(user.twitter_handle)
+      user_handle = user.external_identities.find_by(provider: 'twitter')&.handle
+      cloudinary_image_url(user_handle)
     end
   end
+
 
   def cloudinary_image_url(twitter_handle)
     "https://res.cloudinary.com/#{ENV['CLOUDINARY_HANDLE']}/image/twitter_name/#{twitter_handle}.jpg"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,9 @@ class User < ActiveRecord::Base
   has_many :letters
   has_many :likes
   has_many :external_identities
+  has_one :twitter_identity, -> { where provider: 'twitter' }, class_name: "ExternalIdentity" 
+
+  
 
   class << self
     def find_for_twitter_oauth(auth)
@@ -20,7 +23,7 @@ class User < ActiveRecord::Base
              .first
       if user
         user.update(name: auth.info.name)
-        user.external_identities.find_by(provider: 'twitter').update(
+        user.twitter_identity.update(
           handle: auth.info.nickname, 
           description: auth.info.description, 
           website: auth.info.urls.Website, 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,11 +20,27 @@ class User < ActiveRecord::Base
              .first
       if user
         user.update(name: auth.info.name)
-        user.external_identities.find_by(provider: 'twitter').update(handle: auth.info.nickname, description: auth.info.description, website: auth.info.urls.Website, oauth: auth.credentials.token, name: auth.info.name, image: auth.info.image)
+        user.external_identities.find_by(provider: 'twitter').update(
+          handle: auth.info.nickname, 
+          description: auth.info.description, 
+          website: auth.info.urls.Website, 
+          oauth: auth.credentials.token, 
+          name: auth.info.name, 
+          image: auth.info.image
+        )
         user
       else
         user = User.create(name: auth.info.name)
-        user.external_identities.create(uid: auth.uid, provider: auth.provider, handle: auth.info.nickname, name: auth.info.name, image: auth.info.image, description: auth.info.description, website: auth.info.urls.Website, oauth: auth.credentials.token)    
+        user.external_identities.create(
+          uid: auth.uid, 
+          provider: auth.provider, 
+          handle: auth.info.nickname, 
+          name: auth.info.name, 
+          image: auth.info.image, 
+          description: auth.info.description, 
+          website: auth.info.urls.Website, 
+          oauth: auth.credentials.token
+        )    
         user
       end
     end

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -32,7 +32,7 @@
                 = letter.user.name
                 %br
                 %strong
-                  - twitter_identity = letter.user.external_identities.find_by(provider: 'twitter')
+                  - twitter_identity = letter.user.twitter_identity
                   %a{ href: "https://www.twitter.com/#{twitter_identity.handle}", target: "_blank" }
                     = "@#{twitter_identity.handle}"
                 %br
@@ -54,7 +54,7 @@
         %br
         %div
           %div.pull-left
-            - twitter_identity = letter.user.external_identities.find_by(provider: 'twitter')
+            - twitter_identity = letter.user.twitter_identity
             %a.twitter-share-button{"data-size": "large", "data-hashtags": "whyloveruby", "data-url": "#{root_url}",
                    href: "https://twitter.com/share", class: 'pull-right',
                    "data-text": "Here is @#{twitter_identity.handle}\'s reason to love Ruby. -  #{letter_url(letter)}\n Tell us yours at" }

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -10,6 +10,7 @@
       -else
         = link_to 'Submit', '#', class: 'btn primary pull-right disabled', rel: 'popover', data: {title: 'Oops!!', content: 'You need to login first to submit!!'}
 
+
 %hr
 .row
   .span8
@@ -25,13 +26,15 @@
               - else
                 = link_to 'UpVote', '#', class: 'btn', rel: 'popover', data: {content: "You need to login first to Like it. ", title: 'Oops !!'}
 
+
             .personalInfo.pull-right
               .pull-right.names
                 = letter.user.name
                 %br
                 %strong
-                  %a{ href: "https://www.twitter.com/#{letter.user.twitter_handle}", target: "_blank" }
-                    = "@#{letter.user.twitter_handle}"
+                  - twitter_identity = letter.user.external_identities.find_by(provider: 'twitter')
+                  %a{ href: "https://www.twitter.com/#{twitter_identity.handle}", target: "_blank" }
+                    = "@#{twitter_identity.handle}"
                 %br
                 %small.timeAgo
                   = link_to letter_path(letter) do
@@ -39,6 +42,7 @@
                     ago
               .pull-right.thumbnail.imageWrapper{ style: 'max-height: 50px; max-width: 50px' }
                 = get_twitter_image(letter.user)
+
 
         -#          TODO refactor this
         - unless letter.user_id == 43
@@ -50,9 +54,11 @@
         %br
         %div
           %div.pull-left
-            %a.twitter-share-button{"data-size": "large", "data-hashtags": "whyloveruby",
-                 href: "https://twitter.com/share", class: 'pull-right',
-                 "data-text": "Here is @#{letter.user.twitter_handle}\'s reason to love Ruby. -  #{letter_url(letter)}\n Tell us yours at"}
+            - twitter_identity = letter.user.external_identities.find_by(provider: 'twitter')
+            %a.twitter-share-button{"data-size": "large", "data-hashtags": "whyloveruby", "data-url": "#{root_url}",
+                   href: "https://twitter.com/share", class: 'pull-right',
+                   "data-text": "Here is @#{twitter_identity.handle}\'s reason to love Ruby. -  #{letter_url(letter)}\n Tell us yours at" }
+
 
           .clr
           :javascript

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,6 +11,7 @@
     %meta{:content => "Why Love Ruby", :property => "og:site_name"}/
     %meta{:content => "Why Love Ruby", :itemprop => "name"}
 
+
     %title= "I Love Ruby because .."
     = csrf_meta_tags
     / Le HTML5 shim, for IE6-8 support of HTML elements
@@ -32,6 +33,8 @@
     %script{:src => "//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js"}
 
 
+
+
   %body
     .navbar.navbar-fixed-top.navbar-inverse
       .navbar-inner
@@ -47,18 +50,20 @@
                 %li
                   %span.welcome
                     Welcome,
-                    = current_user.twitter_handle
+                    = current_user.external_identities.find_by(provider: 'twitter')&.handle
                     |
                     = link_to "Logout", destroy_user_session_path, method: 'delete'
               - else
-                %li= link_to 'Login with Twitter' , user_twitter_omniauth_authorize_path
+                %li= link_to 'Login with Twitter' , user_twitter_omniauth_authorize_path, method: :post
               %li=# link_to "Link 1", "/path1"
               %li=# link_to "Link 2", "/path2"
               %li=# link_to "Link 3", "/path3"
 
+
     %div{:style => "position:absolute; top:0; right:0;z-index:1040"}
       = link_to 'https://github.com/rtdp/myloveruby', target: '_blank' do
         %img{:alt => "Beta Version", :border => "0", :src => "/forkme_right_red.png"}
+
 
     .container
       .row
@@ -109,12 +114,14 @@
                         .thumbnail.pull-left{ style: 'max-height: 50px; max-width: 50px' }
                           = get_twitter_image(l.user)
                         .info.pull-left
-                          = truncate("#{l.user.name} (#{l.user.twitter_handle})", length: 27)
+                          - twitter_identity = l.user.external_identities.find_by(provider: 'twitter')
+                          = truncate("#{twitter_identity.name} (#{twitter_identity.handle})", length: 27)
                           %br
                           %small.timeAgo
                             = link_to letter_path(l) do
                               = time_ago_in_words l.created_at
                               ago
+
 
       %footer
         %hr
@@ -131,6 +138,7 @@
         var _gaq = _gaq || [];
         _gaq.push(['_setAccount', 'UA-10763136-15']);
         _gaq.push(['_trackPageview']);
+
 
         (function() {
           var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -50,7 +50,7 @@
                 %li
                   %span.welcome
                     Welcome,
-                    = current_user.external_identities.find_by(provider: 'twitter')&.handle
+                    = current_user.twitter_identity&.handle
                     |
                     = link_to "Logout", destroy_user_session_path, method: 'delete'
               - else
@@ -114,7 +114,7 @@
                         .thumbnail.pull-left{ style: 'max-height: 50px; max-width: 50px' }
                           = get_twitter_image(l.user)
                         .info.pull-left
-                          - twitter_identity = l.user.external_identities.find_by(provider: 'twitter')
+                          - twitter_identity = l.user.twitter_identity
                           = truncate("#{twitter_identity.name} (#{twitter_identity.handle})", length: 27)
                           %br
                           %small.timeAgo

--- a/app/views/letters/show.html.haml
+++ b/app/views/letters/show.html.haml
@@ -15,8 +15,9 @@
               = @letter.user.name
               %br
               %strong
-                %a{ href: "https://www.twitter.com/#{@letter.user.twitter_handle}", target: "_blank" }
-                  = "@#{@letter.user.twitter_handle}"
+                - twitter_identity = @letter.user.external_identities.find_by(provider: 'twitter')
+                %a{ href: "https://www.twitter.com/#{twitter_identity.handle}", target: "_blank" }
+                  = "@#{twitter_identity.handle}"
               %br
               %small.timeAgo
                 = link_to letter_path(@letter) do
@@ -28,9 +29,10 @@
       %br
       %div
         %div.pull-left
+          - twitter_identity = @letter.user.external_identities.find_by(provider: 'twitter')
           %a.twitter-share-button{"data-size": "large", "data-hashtags": "whyloveruby", "data-url": "#{root_url}",
                  href: "https://twitter.com/share", class: 'pull-right',
-                 "data-text": "Here is @#{@letter.user.twitter_handle}\'s reason to love Ruby. -  #{letter_url(@letter)}\n Tell us yours at" }
+                 "data-text": "Here is @#{twitter_identity.handle}\'s reason to love Ruby. -  #{letter_url(@letter)}\n Tell us yours at" }
         .clr
         :javascript
                  !function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");

--- a/app/views/letters/show.html.haml
+++ b/app/views/letters/show.html.haml
@@ -15,7 +15,7 @@
               = @letter.user.name
               %br
               %strong
-                - twitter_identity = @letter.user.external_identities.find_by(provider: 'twitter')
+                - twitter_identity = @letter.user.twitter_identity
                 %a{ href: "https://www.twitter.com/#{twitter_identity.handle}", target: "_blank" }
                   = "@#{twitter_identity.handle}"
               %br
@@ -29,7 +29,7 @@
       %br
       %div
         %div.pull-left
-          - twitter_identity = @letter.user.external_identities.find_by(provider: 'twitter')
+          - twitter_identity = @letter.user.twitter_identity
           %a.twitter-share-button{"data-size": "large", "data-hashtags": "whyloveruby", "data-url": "#{root_url}",
                  href: "https://twitter.com/share", class: 'pull-right',
                  "data-text": "Here is @#{twitter_identity.handle}\'s reason to love Ruby. -  #{letter_url(@letter)}\n Tell us yours at" }

--- a/db/migrate/20231201112603_remover_user_attributes_from_user_table.rb
+++ b/db/migrate/20231201112603_remover_user_attributes_from_user_table.rb
@@ -7,6 +7,5 @@ class RemoverUserAttributesFromUserTable < ActiveRecord::Migration[6.1]
     remove_column :users, :twitter_description, :string
     remove_column :users, :website, :string
     remove_column :users, :image, :string
-    remove_column :users, :email, :string
   end
 end

--- a/db/migrate/20231201112603_remover_user_attributes_from_user_table.rb
+++ b/db/migrate/20231201112603_remover_user_attributes_from_user_table.rb
@@ -1,0 +1,12 @@
+class RemoverUserAttributesFromUserTable < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :users, :uid, :string
+    remove_column :users, :provider, :string
+    remove_column :users, :twitter_oauth, :string
+    remove_column :users, :twitter_handle, :string
+    remove_column :users, :twitter_description, :string
+    remove_column :users, :website, :string
+    remove_column :users, :image, :string
+    remove_column :users, :email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -82,6 +82,7 @@ ActiveRecord::Schema.define(version: 2023_10_11_140047) do
   end
 
   create_table "users", force: :cascade do |t|
+    t.string "email", default: ""
     t.string "encrypted_password", default: ""
     t.datetime "remember_created_at"
     t.integer "sign_in_count", default: 0
@@ -92,14 +93,15 @@ ActiveRecord::Schema.define(version: 2023_10_11_140047) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name"
-    t.string "email"
-    t.string "image"
-    t.string "website"
-    t.string "twitter_description"
-    t.string "twitter_handle"
     t.string "twitter_oauth"
+    t.string "twitter_handle"
+    t.string "twitter_description"
+    t.string "website"
+    t.string "image"
     t.string "provider"
     t.string "uid"
+    t.index ["provider"], name: "index_users_on_provider"
+    t.index ["uid"], name: "index_users_on_uid"
   end
 
   add_foreign_key "external_identities", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -82,7 +82,6 @@ ActiveRecord::Schema.define(version: 2023_10_11_140047) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "email", default: ""
     t.string "encrypted_password", default: ""
     t.datetime "remember_created_at"
     t.integer "sign_in_count", default: 0
@@ -93,15 +92,14 @@ ActiveRecord::Schema.define(version: 2023_10_11_140047) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name"
-    t.string "twitter_oauth"
-    t.string "twitter_handle"
-    t.string "twitter_description"
-    t.string "website"
+    t.string "email"
     t.string "image"
+    t.string "website"
+    t.string "twitter_description"
+    t.string "twitter_handle"
+    t.string "twitter_oauth"
     t.string "provider"
     t.string "uid"
-    t.index ["provider"], name: "index_users_on_provider"
-    t.index ["uid"], name: "index_users_on_uid"
   end
 
   add_foreign_key "external_identities", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -92,6 +92,7 @@ ActiveRecord::Schema.define(version: 2023_12_01_112603) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name"
+    t.string "email"
   end
 
   add_foreign_key "external_identities", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_10_11_140047) do
+ActiveRecord::Schema.define(version: 2023_12_01_112603) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -82,7 +82,6 @@ ActiveRecord::Schema.define(version: 2023_10_11_140047) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "email", default: ""
     t.string "encrypted_password", default: ""
     t.datetime "remember_created_at"
     t.integer "sign_in_count", default: 0
@@ -93,15 +92,6 @@ ActiveRecord::Schema.define(version: 2023_10_11_140047) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name"
-    t.string "twitter_oauth"
-    t.string "twitter_handle"
-    t.string "twitter_description"
-    t.string "website"
-    t.string "image"
-    t.string "provider"
-    t.string "uid"
-    t.index ["provider"], name: "index_users_on_provider"
-    t.index ["uid"], name: "index_users_on_uid"
   end
 
   add_foreign_key "external_identities", "users"

--- a/spec/factories/external_identity.rb
+++ b/spec/factories/external_identity.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+    factory :external_identity do
+      association :user
+      provider { "SomeProvider" }
+      uid { "SomeUID" }
+    end
+  end
+  

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -17,20 +17,26 @@ RSpec.describe ApplicationHelper, type: :helper do
 
     context 'get_twitter_image for User who last signed in before RubyIndiaConf 2023' do
       it 'should render image tag with the twitter handle' do
-        user = User.new(twitter_handle: 'my_twitter_handle', updated_at: Date.parse('2022-12-31').end_of_day)
+        user = User.create(updated_at: Date.parse('2022-12-31').end_of_day)
+        user.external_identities.create(handle: "my_twitter_handle", provider: "twitter", uid: "252152")
         expect(helper.get_twitter_image(user)).to match("cloudinary.*my_twitter_handle\.jpg")
       end
     end
     context 'get_twitter_image for User who last signed in after RubyIndiaConf 2023' do
       it 'should render image tag with twitter handle (in the unlikely case, our User model does not contain the image url)' do
-        user = User.new(twitter_handle: 'my_twitter_handle', updated_at: Date.parse('2024-01-01').end_of_day)
+        user = User.create(updated_at: Date.parse('2024-01-01').end_of_day)
+        user.external_identities.create(handle: "my_twitter_handle", provider: "twitter", uid: "252152")
         expect(helper.get_twitter_image(user)).to match("cloudinary.*my_twitter_handle\.jpg")
       end
-      it 'should render image tag using the URL saved on the User model' do
-        user = User.new(
-          twitter_handle: 'my_twitter_handle',
-          image: 'https://pbs.twimg.com/profile_images/123456789/my_selfie.jpg',
+      it 'should render image tag using the URL saved on the ExternalIdentity model' do
+        user = User.create(
           updated_at: Date.parse('2024-01-01').end_of_day
+        )
+        user.external_identities.create(
+          handle: 'my_twitter_handle',
+          provider: 'twitter',
+          uid: '123456',
+          image: 'https://pbs.twimg.com/profile_images/123456789/my_selfie.jpg'
         )
         image_url = helper.get_twitter_image(user)
         expect(image_url).to_not match("my_twitter_handle\.jpg")

--- a/spec/models/external_identity_spec.rb
+++ b/spec/models/external_identity_spec.rb
@@ -1,5 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe ExternalIdentity, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'ActiveRecord associations' do
+    it { should belong_to(:user) }
+  end
+
+  describe 'ActiveModel validations' do
+    subject { create(:external_identity) } 
+    it { should validate_presence_of(:provider) }
+    it { should validate_uniqueness_of(:provider).scoped_to(:user_id).with_message('has already been taken for this user') }
+
+    it { should validate_uniqueness_of(:uid).scoped_to(:provider).with_message('has already been taken for this provider') }
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,5 +4,6 @@ RSpec.describe User, type: :model do
   describe 'ActiveRecord associations' do
     it { should have_many(:letters) }
     it { should have_many(:likes) }
+    it { should have_many(:external_identities) }
   end
 end


### PR DESCRIPTION
Overview:

This PR is removing some user fields from user table because we copied and pasted those attributes to ExternalIdentity table. We are also using ExternalIdentity from log in with twitter.